### PR TITLE
fix: update serialize-javascript to 7.0.5

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9319,9 +9319,9 @@
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -23,7 +23,7 @@
     "react-dev-utils": {
       "fork-ts-checker-webpack-plugin": "9.1.0"
     },
-    "serialize-javascript": "7.0.3",
+    "serialize-javascript": "7.0.5",
     "uuid": "11.1.1",
     "webpack-dev-server": "5.2.6"
   },


### PR DESCRIPTION
## Summary

- update the docs override for `serialize-javascript` from 7.0.3 to 7.0.5
- regenerate the docs lockfile for GitHub Dependabot alert #362

## Verification

- `npm ci --ignore-scripts` (docs)
- `npm run build` (docs)
- `npm test` — 2 suites / 3 tests passed
- `npm run lint:js` — 0 errors, 13 existing warnings
- `npm ls serialize-javascript --all` — resolves 7.0.5

The existing root CSS lint baseline remains unchanged (229 errors in untouched CSS files).
